### PR TITLE
Alex/env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.env
 
 ### STS ###
 .apt_generated

--- a/ConfigService/Dockerfile
+++ b/ConfigService/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:21-jdk-slim
+
+COPY /build/libs/ConfigService-0.0.1-SNAPSHOT.jar app.jar
+
+ENTRYPOINT [ "java" , "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" , "-jar" , "app.jar"]
+EXPOSE 8888

--- a/ConfigService/build.gradle
+++ b/ConfigService/build.gradle
@@ -18,18 +18,26 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+    sourceCompatibility = '21'
+    targetCompatibility = '21'
+}
+
+ext {
+    set('springCloudVersion', "2023.0.3")
+}
+
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.apache.groovy:groovy'
+    implementation 'org.springframework.cloud:spring-cloud-config-server'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'mysql:mysql-connector-java:8.0.33'
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
 }
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.3"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
 }
 
@@ -39,8 +47,10 @@ tasks.named('test') {
 
 spotless {
     format 'misc', {
+        // define the files to apply `misc` to
         target '*.gradle', '.gitattributes', '.gitignore'
 
+        // define the steps to apply to those files
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()

--- a/ConfigService/docker-compose.yml
+++ b/ConfigService/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${CNFG_HOST_PORT}:${CNFG_HOST_PORT}"
+      - "${CNFG_SERVER_PORT}:${CNFG_CONTAINER_PORT}"
     env_file:
      - .env
 networks:

--- a/ConfigService/docker-compose.yml
+++ b/ConfigService/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  config-service:
+    image: configservice
+    container_name: config-service
+    networks:
+      - netw
+    ports:
+      - "8888:8888"
+networks:
+  netw:
+    driver: bridge
+    external: true

--- a/ConfigService/docker-compose.yml
+++ b/ConfigService/docker-compose.yml
@@ -3,9 +3,11 @@ services:
     image: configservice
     container_name: config-service
     networks:
-      - netw
+      - ${NETWORK_NAME}
     ports:
-      - "8888:8888"
+      - "${CNFG_HOST_PORT}:${CNFG_HOST_PORT}"
+    env_file:
+     - .env
 networks:
   netw:
     driver: bridge

--- a/ConfigService/src/main/java/CS4337/Project/ConfigServer.java
+++ b/ConfigService/src/main/java/CS4337/Project/ConfigServer.java
@@ -1,0 +1,14 @@
+package CS4337.Project;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServer {
+
+  public static void main(String[] arguments) {
+    SpringApplication.run(ConfigServer.class, arguments);
+  }
+}

--- a/ConfigService/src/main/resources/application.properties
+++ b/ConfigService/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+server.port=8888
+spring.cloud.config.server.git.uri=https://github.com/AlB1111122/BigDataConfig
+spring.profiles.active=dev
+spring.cloud.config.server.git.clone-on-start=true
+spring.security.user.name=root
+spring.security.user.password=1234

--- a/ConfigService/src/main/resources/application.properties
+++ b/ConfigService/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-server.port=8888
+server.port=${CNFG_HOST_PORT}
 spring.cloud.config.server.git.uri=https://github.com/AlB1111122/BigDataConfig
-spring.profiles.active=dev
+spring.profiles.active=${ENV}
 spring.cloud.config.server.git.clone-on-start=true
-spring.security.user.name=root
-spring.security.user.password=1234
+spring.security.user.name=${USER_NAME}
+spring.security.user.password=${USER_PSWD}

--- a/ConfigService/src/main/resources/application.properties
+++ b/ConfigService/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port=${CNFG_HOST_PORT}
+server.port=${CNFG_SERVER_PORT}
 spring.cloud.config.server.git.uri=https://github.com/AlB1111122/BigDataConfig
 spring.cloud.config.server.git.clone-on-start=true
 spring.security.user.name=${USER_NAME}

--- a/ConfigService/src/main/resources/application.properties
+++ b/ConfigService/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 server.port=${CNFG_HOST_PORT}
 spring.cloud.config.server.git.uri=https://github.com/AlB1111122/BigDataConfig
-spring.profiles.active=${ENV}
 spring.cloud.config.server.git.clone-on-start=true
 spring.security.user.name=${USER_NAME}
 spring.security.user.password=${USER_PSWD}

--- a/MessagingService/Dockerfile
+++ b/MessagingService/Dockerfile
@@ -3,4 +3,4 @@ FROM openjdk:21-jdk-slim
 COPY build/libs/MessagingService-0.0.1-SNAPSHOT.jar app.jar
 
 ENTRYPOINT [ "java" , "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" , "-jar" , "app.jar"]
-EXPOSE 8080
+EXPOSE ${MSG_CONTAINER_PORT}

--- a/MessagingService/build.gradle
+++ b/MessagingService/build.gradle
@@ -32,6 +32,13 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.33'
     implementation 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.3"
+    }
 }
 
 tasks.named('test') {

--- a/MessagingService/docker-compose.yml
+++ b/MessagingService/docker-compose.yml
@@ -6,21 +6,24 @@ services:
       MYSQL_ROOT_PASSWORD: 1234
       MYSQL_DATABASE: messaging_service
     networks:
-      - net
+      - ${NETWORK_NAME}
     ports:
-      - "3306:3306"
+      - "${MSG_MYSQL_HOST_PORT}:${MSG_MYSQL_CONTAINER_PORT}"
     volumes:
       - "./src/main/init.sql:/docker-entrypoint-initdb.d/init.sql"
 
   messaging-service:
-    build: .
-    container_name: messaging-service
+    image: msgservice
+    container_name: ${MSG_CONTAINER}
     depends_on:
       - mysql
     networks:
-      - net
+      - ${NETWORK_NAME}
     ports:
-      - "8080:8080"
+      - "${MSG_HOST_PORT}:${MSG_CONTAINER_PORT}"
+    env_file:
+      - .env
 networks:
-  net:
+  netw:
     driver: bridge
+    external: true

--- a/MessagingService/docker-compose.yml
+++ b/MessagingService/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${MSG_MYSQL_HOST_PORT}:${MSG_MYSQL_CONTAINER_PORT}"
+      - "${MSG_MYSQL_SERVER_PORT}:${MSG_MYSQL_CONTAINER_PORT}"
     volumes:
       - "./src/main/init.sql:/docker-entrypoint-initdb.d/init.sql"
 
@@ -20,7 +20,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${MSG_HOST_PORT}:${MSG_CONTAINER_PORT}"
+      - "${MSG_SERVER_PORT}:${MSG_CONTAINER_PORT}"
     env_file:
       - .env
 networks:

--- a/MessagingService/src/main/resources/application.properties
+++ b/MessagingService/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=MessagingService
-server.port=8080
-spring.datasource.url=jdbc:mysql://messagingDB:3306/messaging_service
+server.port=${MSG_CONTAINER_PORT}
+spring.datasource.url=jdbc:mysql://messagingDB:${MSG_MYSQL_CONTAINER_PORT}/messaging_service
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/MessagingService/src/main/resources/application.properties
+++ b/MessagingService/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.application.name=MessagingService
-server.port=${MSG_CONTAINER_PORT}
-spring.datasource.url=jdbc:mysql://messagingDB:${MSG_MYSQL_CONTAINER_PORT}/messaging_service
-spring.datasource.username=root
-spring.datasource.password=1234
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.cloud.config.name=msg
+spring.profiles.active=${ENV}
+spring.config.import=configserver:http://${USER_NAME}:${USER_PSWD}@config-service:8888

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Project for Module CS4337 'Big Data Management and Security'. 
 
 Contributors :
-  -  Alex Butler 
+  -  Alex Butler(21338787)
   -  Mohd Humayun
   -  Honglin Li
   -  Bayan Nezamabad

--- a/ShopService/Dockerfile
+++ b/ShopService/Dockerfile
@@ -3,4 +3,4 @@ FROM openjdk:21-jdk-slim
 COPY /build/libs/ShopService-0.0.1-SNAPSHOT.jar app.jar
 
 ENTRYPOINT [ "java" , "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" , "-jar" , "app.jar"]
-EXPOSE 9090
+EXPOSE ${SHOP_CONTAINER_PORT}

--- a/ShopService/build.gradle
+++ b/ShopService/build.gradle
@@ -24,6 +24,13 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'mysql:mysql-connector-java:8.0.33'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.3"
+    }
 }
 
 tasks.named('test') {

--- a/ShopService/docker-compose.yml
+++ b/ShopService/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${SHOP_MYSQL_HOST_PORT}:${SHOP_MYSQL_CONTAINER_PORT}"
+      - "${SHOP_MYSQL_SERVER_PORT}:${SHOP_MYSQL_CONTAINER_PORT}"
   shop-service:
     image: shopservice
     depends_on:
@@ -16,7 +16,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${SHOP_HOST_PORT}:${SHOP_CONTAINER_PORT}"
+      - "${SHOP_SERVER_PORT}:${SHOP_CONTAINER_PORT}"
     env_file:
       - .env
 networks:

--- a/ShopService/docker-compose.yml
+++ b/ShopService/docker-compose.yml
@@ -1,50 +1,25 @@
 services:
   mysql:
     image: mysql:latest
-    container_name: userdb
+    container_name: shopdb
     environment:
       MYSQL_ROOT_PASSWORD: 1234
-      MYSQL_DATABASE: user_service
     networks:
-      - net
+      - ${NETWORK_NAME}
     ports:
-      - "3306:3306"
-    volumes:
-      - "./UserService/src/main/init.sql:/docker-entrypoint-initdb.d/init.sql"
-  java-app:
-    image: springbootdemo
-    container_name: project-app
-    networks:
-      - net
-    ports:
-      - "8080:8080"
-  user-service:
-    build:
-      context: UserService
-      dockerfile: Dockerfile
-    image: userservice
-    depends_on :
+      - "${SHOP_MYSQL_HOST_PORT}:${SHOP_MYSQL_CONTAINER_PORT}"
+  shop-service:
+    image: shopservice
+    depends_on:
       - mysql
-    container_name: user-service
+    container_name: ${SHOP_CONTAINER}
     networks:
-      - net
+      - ${NETWORK_NAME}
     ports:
-      - "9090:9090"
+      - "${SHOP_HOST_PORT}:${SHOP_CONTAINER_PORT}"
+    env_file:
+      - .env
 networks:
-  net:
+  netw:
     driver: bridge
-
-    shop-service:
-      build:
-        context: ShopService
-        dockerfile: Dockerfile
-      depends_on:
-        - mysql
-      container_name: shop-service
-      networks:
-        - net
-      ports:
-        - "8080:8080"
-    networks:
-      net:
-        driver: bridge
+    external: true

--- a/ShopService/src/main/resources/application.properties
+++ b/ShopService/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.application.name=ShopService
-server.port=${SHOP_CONTAINER_PORT}
-spring.datasource.url=jdbc:mysql://shopdb:${SHOP_MYSQL_CONTAINER_PORT}/shop_service
-spring.datasource.username=root
-spring.datasource.password=1234
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.cloud.config.name=shop
+spring.profiles.active=${ENV}
+spring.config.import=configserver:http://${USER_NAME}:${USER_PSWD}@config-service:8888

--- a/ShopService/src/main/resources/application.properties
+++ b/ShopService/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=ShopService
-server.port=9090
-spring.datasource.url=jdbc:mysql://shopdb:3306/shop_service
+server.port=${SHOP_CONTAINER_PORT}
+spring.datasource.url=jdbc:mysql://shopdb:${SHOP_MYSQL_CONTAINER_PORT}/shop_service
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/UserService/Dockerfile
+++ b/UserService/Dockerfile
@@ -3,4 +3,4 @@ FROM openjdk:21-jdk-slim
 COPY /build/libs/UserService-0.0.1-SNAPSHOT.jar app.jar
 
 ENTRYPOINT [ "java" , "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" , "-jar" , "app.jar"]
-EXPOSE 9090
+EXPOSE ${USER_CONTAINER_PORT}

--- a/UserService/docker-compose.yml
+++ b/UserService/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${USER_MYSQL_HOST_PORT}:${USER_MYSQL_CONTAINER_PORT}"
+      - "${USER_MYSQL_SERVER_PORT}:${USER_MYSQL_CONTAINER_PORT}"
     volumes:
       - "./src/main/init.sql:/docker-entrypoint-initdb.d/init.sql"
   user-service:
@@ -19,7 +19,7 @@ services:
     networks:
       - ${NETWORK_NAME}
     ports:
-      - "${USER_HOST_PORT}:${USER_CONTAINER_PORT}"
+      - "${USER_SERVER_PORT}:${USER_CONTAINER_PORT}"
     env_file:
       - .env
 networks:

--- a/UserService/docker-compose.yml
+++ b/UserService/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: mysql:latest
     container_name: userdb
     environment:
-      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_ROOT_PASSWORD: ${USER_PSWD}
       MYSQL_DATABASE: user_service
     networks:
       - ${NETWORK_NAME}

--- a/UserService/docker-compose.yml
+++ b/UserService/docker-compose.yml
@@ -6,20 +6,23 @@ services:
       MYSQL_ROOT_PASSWORD: 1234
       MYSQL_DATABASE: user_service
     networks:
-      - net
+      - ${NETWORK_NAME}
     ports:
-      - "3306:3306"
+      - "${USER_MYSQL_HOST_PORT}:${USER_MYSQL_CONTAINER_PORT}"
     volumes:
       - "./src/main/init.sql:/docker-entrypoint-initdb.d/init.sql"
   user-service:
     image: userservice
     depends_on :
       - mysql
-    container_name: user-service
+    container_name: ${USER_CONTAINER}
     networks:
-      - net
+      - ${NETWORK_NAME}
     ports:
-      - "9090:9090"
+      - "${USER_HOST_PORT}:${USER_CONTAINER_PORT}"
+    env_file:
+      - .env
 networks:
-  net:
+  netw:
     driver: bridge
+    external: true

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.application.name=UserService
-server.port=${USER_CONTAINER_PORT}
-spring.datasource.url=jdbc:mysql://userdb:${USER_MYSQL_CONTAINER_PORT}/user_service
-spring.datasource.username=root
-spring.datasource.password=1234
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.cloud.config.name=user
+spring.profiles.active=dev 
+spring.config.import=configserver:http://root:1234@config-service:8888

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=UserService
 spring.cloud.config.name=user
+spring.profiles.active=${ENV}
 spring.config.import=configserver:http://${USER_NAME}:${USER_PSWD}@config-service:8888

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=UserService
-server.port=9090
-spring.datasource.url=jdbc:mysql://userdb:3306/user_service
+server.port=${USER_CONTAINER_PORT}
+spring.datasource.url=jdbc:mysql://userdb:${USER_MYSQL_CONTAINER_PORT}/user_service
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 spring.application.name=UserService
 spring.cloud.config.name=user
-spring.profiles.active=dev 
-spring.config.import=configserver:http://root:1234@config-service:8888
+spring.config.import=configserver:http://${USER_NAME}:${USER_PSWD}@config-service:8888

--- a/env.sh
+++ b/env.sh
@@ -1,22 +1,17 @@
 #!/bin/bash
-TARGET_DIRS=("UserService" "ShopService" "MessagingService" "BanService")
-
-#NB!! remember to make the external network(nessesary to let container http eachother):
-#`docker network create netw`
-    #export NETWORK_NAME=netw
-    #user service
-    #export USER_HOST_PORT=9090
-    #export USER_CONTAINER_PORT=9090
-    #export USER_CONTAINER=user-service
-    #export USER_MYSQL_HOST_PORT=3306
-    #export USER_MYSQL_CONTAINER_PORT=3306
-
+TARGET_DIRS=("UserService" "ShopService" "MessagingService" "BanService" "ConfigService")
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 #build with `docker build -t msgservice .` idk why otherwise env vars dont work
 for TARGET_DIR in "${TARGET_DIRS[@]}"; do
     touch $SCRIPT_DIR/$TARGET_DIR/.env
     {
+        echo "export ENV=dev"
+        echo "export USER_NAME=root"
+        echo "export USER_PSWD=1234"
         echo "export NETWORK_NAME=netw"
+        echo "#config service"
+        echo "export CNFG_HOST_PORT=8888"
+        echo "export CNFG_CONTAINER_PORT=8888"
         echo "#user service"
         echo "export USER_HOST_PORT=9090"
         echo "export USER_CONTAINER_PORT=9090"

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 TARGET_DIRS=("UserService" "ShopService" "MessagingService" "BanService")
 
+#NB!! remember to make the external network(nessesary to let container http eachother):
+#`docker network create netw`
     #export NETWORK_NAME=netw
     #user service
     #export USER_HOST_PORT=9090
@@ -27,5 +29,11 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
         echo "SHOP_CONTAINER=shop-service"
         echo "SHOP_MYSQL_HOST_PORT=3308"
         echo "SHOP_MYSQL_CONTAINER_PORT=3306"
+        echo "#messaging service"
+        echo "MSG_HOST_PORT=8081"
+        echo "MSG_CONTAINER_PORT=8081"
+        echo "MSG_CONTAINER=messaging-service"
+        echo "MSG_MYSQL_HOST_PORT=3308"
+        echo "MSG_MYSQL_CONTAINER_PORT=3306"
     } > "$SCRIPT_DIR/$TARGET_DIR/.env"
 done

--- a/env.sh
+++ b/env.sh
@@ -12,28 +12,28 @@ TARGET_DIRS=("UserService" "ShopService" "MessagingService" "BanService")
     #export USER_MYSQL_CONTAINER_PORT=3306
 
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
-
+#build with `docker build -t msgservice .` idk why otherwise env vars dont work
 for TARGET_DIR in "${TARGET_DIRS[@]}"; do
     touch $SCRIPT_DIR/$TARGET_DIR/.env
     {
-        echo "NETWORK_NAME=netw"
+        echo "export NETWORK_NAME=netw"
         echo "#user service"
-        echo "USER_HOST_PORT=9090"
-        echo "USER_CONTAINER_PORT=9090"
-        echo "USER_CONTAINER=user-service"
-        echo "USER_MYSQL_HOST_PORT=3306"
-        echo "USER_MYSQL_CONTAINER_PORT=3306"
+        echo "export USER_HOST_PORT=9090"
+        echo "export USER_CONTAINER_PORT=9090"
+        echo "export USER_CONTAINER=user-service"
+        echo "export USER_MYSQL_HOST_PORT=3306"
+        echo "export USER_MYSQL_CONTAINER_PORT=3306"
         echo "#shop service"
-        echo "SHOP_HOST_PORT=8080"
-        echo "SHOP_CONTAINER_PORT=8080"
-        echo "SHOP_CONTAINER=shop-service"
-        echo "SHOP_MYSQL_HOST_PORT=3308"
-        echo "SHOP_MYSQL_CONTAINER_PORT=3306"
+        echo "export SHOP_HOST_PORT=8080"
+        echo "export SHOP_CONTAINER_PORT=8080"
+        echo "export SHOP_CONTAINER=shop-service"
+        echo "export SHOP_MYSQL_HOST_PORT=3308"
+        echo "export SHOP_MYSQL_CONTAINER_PORT=3306"
         echo "#messaging service"
-        echo "MSG_HOST_PORT=8081"
-        echo "MSG_CONTAINER_PORT=8081"
-        echo "MSG_CONTAINER=messaging-service"
-        echo "MSG_MYSQL_HOST_PORT=3308"
-        echo "MSG_MYSQL_CONTAINER_PORT=3306"
+        echo "export MSG_HOST_PORT=8081"
+        echo "export MSG_CONTAINER_PORT=8081"
+        echo "export MSG_CONTAINER=messaging-service"
+        echo "export MSG_MYSQL_HOST_PORT=3308"
+        echo "export MSG_MYSQL_CONTAINER_PORT=3306"
     } > "$SCRIPT_DIR/$TARGET_DIR/.env"
 done

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+TARGET_DIRS=("UserService" "ShopService" "MessagingService" "BanService")
+
+    #export NETWORK_NAME=netw
+    #user service
+    #export USER_HOST_PORT=9090
+    #export USER_CONTAINER_PORT=9090
+    #export USER_CONTAINER=user-service
+    #export USER_MYSQL_HOST_PORT=3306
+    #export USER_MYSQL_CONTAINER_PORT=3306
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+for TARGET_DIR in "${TARGET_DIRS[@]}"; do
+    touch $SCRIPT_DIR/$TARGET_DIR/.env
+    {
+        echo "NETWORK_NAME=netw"
+        echo "#user service"
+        echo "USER_HOST_PORT=9090"
+        echo "USER_CONTAINER_PORT=9090"
+        echo "USER_CONTAINER=user-service"
+        echo "USER_MYSQL_HOST_PORT=3306"
+        echo "USER_MYSQL_CONTAINER_PORT=3306"
+    } > "$SCRIPT_DIR/$TARGET_DIR/.env"
+done

--- a/env.sh
+++ b/env.sh
@@ -21,5 +21,11 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
         echo "USER_CONTAINER=user-service"
         echo "USER_MYSQL_HOST_PORT=3306"
         echo "USER_MYSQL_CONTAINER_PORT=3306"
+        echo "#shop service"
+        echo "SHOP_HOST_PORT=8080"
+        echo "SHOP_CONTAINER_PORT=8080"
+        echo "SHOP_CONTAINER=shop-service"
+        echo "SHOP_MYSQL_HOST_PORT=3308"
+        echo "SHOP_MYSQL_CONTAINER_PORT=3306"
     } > "$SCRIPT_DIR/$TARGET_DIR/.env"
 done

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 TARGET_DIRS=("UserService" "ShopService" "MessagingService" "BanService" "ConfigService")
+#refrence ports, ect in https://github.com/AlB1111122/BigDataConfig/tree/main/ports to update
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 #build with `docker build -t msgservice .` idk why otherwise env vars dont work
 for TARGET_DIR in "${TARGET_DIRS[@]}"; do
@@ -10,25 +11,25 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
         echo "export USER_PSWD=1234"
         echo "export NETWORK_NAME=netw"
         echo "#config service"
-        echo "export CNFG_HOST_PORT=8888"
+        echo "export CNFG_SERVER_PORT=8888"
         echo "export CNFG_CONTAINER_PORT=8888"
         echo "#user service"
-        echo "export USER_HOST_PORT=9090"
+        echo "export USER_SERVER_PORT=9090"
         echo "export USER_CONTAINER_PORT=9090"
         echo "export USER_CONTAINER=user-service"
-        echo "export USER_MYSQL_HOST_PORT=3306"
+        echo "export USER_MYSQL_SERVER_PORT=3306"
         echo "export USER_MYSQL_CONTAINER_PORT=3306"
         echo "#shop service"
-        echo "export SHOP_HOST_PORT=8080"
+        echo "export SHOP_SERVER_PORT=8080"
         echo "export SHOP_CONTAINER_PORT=8080"
         echo "export SHOP_CONTAINER=shop-service"
-        echo "export SHOP_MYSQL_HOST_PORT=3308"
+        echo "export SHOP_MYSQL_SERVER_PORT=3307"
         echo "export SHOP_MYSQL_CONTAINER_PORT=3306"
         echo "#messaging service"
-        echo "export MSG_HOST_PORT=8081"
+        echo "export MSG_SERVER_PORT=8081"
         echo "export MSG_CONTAINER_PORT=8081"
         echo "export MSG_CONTAINER=messaging-service"
-        echo "export MSG_MYSQL_HOST_PORT=3308"
+        echo "export MSG_MYSQL_SERVER_PORT=3308"
         echo "export MSG_MYSQL_CONTAINER_PORT=3306"
     } > "$SCRIPT_DIR/$TARGET_DIR/.env"
 done

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,5 @@ rootProject.name = 'Project'
 include 'UserService'
 include 'MessagingService'
 include 'ShopService'
+include 'ConfigService'
 


### PR DESCRIPTION
## Summary
https://trello.com/c/PRvMErcI
<!-- Summarize changes and add a link to the zenhub card -->
add a script to make .env in root that will make .envs for each module so there is a single SOT for ports and such for docker and stores cloud config username and password

make a cloud config service that will store the .properties for the services
tried had to make it DRY but wasnt possible due to how .properties works

modified docker composes to use the vars. now all services can use the env  vars to know where the other containers are. 

###  - NB!!! also made an external network (netw) because it is required for inter-container http req used by all services in docker-compose.
###  - NB!! have to have config service running for services to run as otherwise it wont know what ports its using

I moved some modules to other ports as they were clashing.
In  future keep using the env.sh to make new modules

## How to verify
<!-- Explain how to verify that the changes worked-->
 - run env.sh to generate the .env
 - make the docker network `docker network create netw `
 - build and run config service
 - build and run other services, make sure they work

make sure your docker build and compose works correctly and db works

## Tests
<!-- Note the tests added if any-->

## Related
<!-- Note related issues if any-->